### PR TITLE
Yegoris b contribution

### DIFF
--- a/CezaurusLMS/urls.py
+++ b/CezaurusLMS/urls.py
@@ -13,7 +13,7 @@ Including another URLconf
     1. Import the include() function: from django.conf.urls import url, include
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
-from django.conf.urls import url, include
+from django.urls import include, re_path as url
 from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # CezaurusLMS
+Now it's gonna run with Django 4.2.5

--- a/communities/models.py
+++ b/communities/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.contrib.auth.models import Group, User, Permission
 from communities.exceptions import *
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from django.shortcuts import reverse, redirect
 
 

--- a/communities/urls.py
+++ b/communities/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, re_path as url
 import communities.views as comm_views
 urlpatterns = [
 

--- a/communities/views.py
+++ b/communities/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
 from communities.forms import *
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 
 
 @login_required()

--- a/core/forms.py
+++ b/core/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 import core.validators as val
 
 

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, re_path as url
 from core.views import people, index, signup, username_validate, search
 from django.contrib.auth import views as auth_views
 from core.views import communities

--- a/core/validators.py
+++ b/core/validators.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 import re
 
 

--- a/core/views.py
+++ b/core/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect, reverse
 from django.contrib.auth.models import User
 from django.contrib.auth import authenticate, login
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from core.forms import SignUpForm
 from django.http import HttpResponse, JsonResponse
 from django.core.exceptions import ValidationError

--- a/courser/urls.py
+++ b/courser/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, re_path as url
 import courser.views as courser_views
 
 

--- a/messenger/urls.py
+++ b/messenger/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, re_path as url
 import messenger.views as mess_views
 
 urlpatterns = [

--- a/profiler/models.py
+++ b/profiler/models.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 from django.dispatch import receiver
 from django.db.models.signals import post_save
 from django.contrib.auth.models import User
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from profiler.exceptions import AlreadyExistsError, AlreadyFriendsError, AlreadySentRequestToYouError
 from django.conf import settings
 from communities.models import Community

--- a/profiler/urls.py
+++ b/profiler/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import include, re_path as url
 from profiler.views import *
 from messenger.views import *
 

--- a/profiler/views.py
+++ b/profiler/views.py
@@ -6,7 +6,7 @@ from django.contrib.auth.decorators import login_required
 from profiler.models import ProfileWallPost, Friendship, FriendshipRequest
 from profiler.forms import ProfileForm, ChangePasswordForm
 from django.contrib import messages
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import update_session_auth_hash
 from PIL import Image
 from django.conf import settings as django_settings


### PR DESCRIPTION
Depricated imports are updated as  follows :  "from django.utils.translation import ugettext as _"  changed to "from django.utils.translation import gettext_lazy as _" and "from django.conf.urls import url"  changed to "from django.urls import include, re_path as url". These changes let the site run with Django 4.2.5